### PR TITLE
fixed history line display

### DIFF
--- a/monopoly.py
+++ b/monopoly.py
@@ -122,11 +122,8 @@ def update_history(message: str):
                 history.append(message[:40] + " " * (40 - len(message)))
                 message = message[40:]
         history.append(message + " " * (40 - len(message)))
-        #if len(history) > 30:
-        #    while(len(history) > 30):
-        #        history.pop(0)
     while(len(history) > 30):
-        del history[0]
+        history.pop(0)
     refresh_h_and_s()
 
 def update_status(p: MonopolyPlayer, update: str, status: list = status, mode: str = "normal", property_id: str = ""):

--- a/monopoly.py
+++ b/monopoly.py
@@ -122,9 +122,11 @@ def update_history(message: str):
                 history.append(message[:40] + " " * (40 - len(message)))
                 message = message[40:]
         history.append(message + " " * (40 - len(message)))
-        if len(history) > 30:
-            while(len(history) > 30):
-                history.pop(0)
+        #if len(history) > 30:
+        #    while(len(history) > 30):
+        #        history.pop(0)
+    while(len(history) > 30):
+        del history[0]
     refresh_h_and_s()
 
 def update_status(p: MonopolyPlayer, update: str, status: list = status, mode: str = "normal", property_id: str = ""):


### PR DESCRIPTION
I fixed the History so that it pretty much always displays 30 lines. I only changed the update_history function. I moved the while loop that removes the extra lines outside of the conditional statement that checks whether or not the most recent line is a player title.